### PR TITLE
chore: migrate GitHub Actions to Ubicloud runners

### DIFF
--- a/.github/workflows/ci-live.yml
+++ b/.github/workflows/ci-live.yml
@@ -25,7 +25,7 @@ jobs:
       contains(github.event.comment.body, '/run-live-tests') &&
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'COLLABORATOR')
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: read
       actions: write
@@ -68,7 +68,7 @@ jobs:
   live-tests:
     name: Run Live API Tests
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
 
     steps:
       - name: Checkout code
@@ -26,7 +26,7 @@ jobs:
         run: bun run lint:verbose
 
   typecheck:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
 
     steps:
       - name: Checkout code
@@ -44,7 +44,7 @@ jobs:
         run: bun run typecheck:verbose
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
 
     steps:
       - name: Checkout code
@@ -65,7 +65,7 @@ jobs:
         run: bun run build
 
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   scanning:
     name: GitGuardian scan
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:


### PR DESCRIPTION
## Summary

This PR migrates GitHub Actions workflows from `ubuntu-latest` to `ubicloud-standard-2` runners.

## Why Ubicloud?

- **Cost-effective**: Ubicloud runners are more affordable than GitHub-hosted runners
- **Performance**: Comparable or better performance for most workloads
- **Compatibility**: Drop-in replacement for Ubuntu-based workflows

## Changes

- Updated `runs-on: ubuntu-latest` → `runs-on: ubicloud-standard-2` in all workflow files