### PR TITLE
chore: setup renovate for dependency updates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@release-it/keep-a-changelog": "^7.0.0",
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.5",
         "@types/nock": "^11.1.0",
         "@types/node": "^22",
         "lefthook": "^2.0.13",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@release-it/keep-a-changelog": "^7.0.0",
-    "@types/bun": "latest",
+    "@types/bun": "^1.3.5",
     "@types/nock": "^11.1.0",
     "@types/node": "^22",
     "lefthook": "^2.0.13",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits"
+  ],
+  "labels": ["dependencies"],
+  "automerge": false,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Core API client - review separately",
+      "matchPackageNames": ["@lasuillard/raindrop-client"],
+      "groupName": null
+    },
+    {
+      "description": "TypeScript - can introduce breaking type checks",
+      "matchPackageNames": ["typescript"],
+      "groupName": null
+    },
+    {
+      "description": "Group minor/patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackageNames": ["@lasuillard/raindrop-client", "typescript"],
+      "groupName": "minor and patch dependencies"
+    },
+    {
+      "description": "Group type definitions",
+      "matchPackagePatterns": ["^@types/"],
+      "groupName": "type definitions"
+    }
+  ],
+  "schedule": ["before 6am on monday"]
+}


### PR DESCRIPTION
## Summary

Sets up [Renovate](https://github.com/apps/renovate) for automated dependency update PRs.

## Changes

- **renovate.json** - Configuration with:
  - `@lasuillard/raindrop-client` reviewed separately (core API dependency)
  - `typescript` reviewed separately (can introduce breaking type checks)
  - Lockfile maintenance enabled
  - Minor/patch updates grouped to reduce PR noise
  - Weekly schedule (Monday before 6am)
  - Semantic commit messages
  - No automerge

- **package.json** - Pin `@types/bun` to `^1.3.5` (was `"latest"` which Renovate can't track)

## Next Steps

After merging, install the [Renovate GitHub App](https://github.com/apps/renovate) on this repo.