### PR TITLE
Fix npm-installed CLI startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Test npm package artifact
+        run: bun run test:package
+
   format:
     runs-on: ubicloud-standard-2
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:live:verbose": "RDCLI_API_DELAY_MS=250 bun test --no-parallel src/**/*.live.test.ts",
     "test:all": "RDCLI_API_DELAY_MS=250 bash scripts/check.sh test:all",
     "test:all:verbose": "RDCLI_API_DELAY_MS=250 bun test src",
+    "test:package": "bash scripts/test-package.sh",
     "lint": "bash scripts/check.sh lint",
     "lint:fix": "oxlint --type-aware --fix src/",
     "lint:verbose": "oxlint --type-aware src/",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "bun build src/cli.ts --outdir dist --target node --format esm && echo '#!/usr/bin/env node' | cat - dist/cli.js > dist/temp && mv dist/temp dist/cli.js && bun run build:dts",
+    "build": "bun build src/cli.ts --outdir dist --target node --format esm && chmod +x dist/cli.js && bun run build:dts",
     "build:dts": "tsc --emitDeclarationOnly --declaration --outDir dist",
     "dev": "bun src/index.ts",
     "test": "bash scripts/check.sh test",

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Smoke test the npm package artifact exactly as users install it.
+# This catches packaging-only failures such as invalid bin paths, missing files,
+# duplicate shebangs, and runtime assumptions about the installed layout.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP_DIR="$(mktemp -d)"
+TARBALL=""
+cleanup() {
+  rm -rf "$TMP_DIR"
+  if [[ -n "$TARBALL" && -f "$TARBALL" ]]; then
+    rm -f "$TARBALL"
+  fi
+}
+trap cleanup EXIT
+
+bun run build >/dev/null
+
+TARBALL="$(npm pack --silent | tail -n 1)"
+npm install -g --prefix "$TMP_DIR/prefix" --ignore-scripts "./$TARBALL" >/dev/null
+
+BIN="$TMP_DIR/prefix/bin/rdcli"
+EXPECTED_VERSION="$(node -p "require('./package.json').version")"
+ACTUAL_VERSION="$($BIN --version)"
+
+if [[ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]]; then
+  echo "Expected rdcli --version to output '$EXPECTED_VERSION', got '$ACTUAL_VERSION'" >&2
+  exit 1
+fi
+
+"$BIN" --help >/dev/null
+
+echo "Package smoke test passed"

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -62,6 +62,11 @@ const checks: CheckConfig[] = [
     command: ["prettier", "--check", "src/**/*.ts"],
     verboseHint: "bun run format:check:verbose",
   },
+  {
+    name: "Package smoke test",
+    command: ["bash", "scripts/test-package.sh"],
+    verboseHint: "bun run test:package",
+  },
 ];
 
 async function runCheckSimple(config: CheckConfig): Promise<CheckResult> {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -10,9 +10,7 @@
  */
 
 import { Command, CommanderError, Option } from "commander";
-import { readFileSync } from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
+import pkg from "../../package.json" with { type: "json" };
 import type { CliContext } from "./context.js";
 import { OUTPUT_FORMATS } from "../types/index.js";
 import { createAuthCommand } from "../commands/auth.js";
@@ -28,9 +26,6 @@ import { setDebugEnabled, setVerboseEnabled, debug } from "../utils/debug.js";
 import { setTimeoutSeconds, validateTimeout, DEFAULT_TIMEOUT_SECONDS } from "../utils/timeout.js";
 import { configureStyledHelpRecursive } from "../utils/help-formatter.js";
 import { UsageError } from "../utils/errors.js";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf-8"));
 
 /**
  * Create root-level shortcuts for bookmark commands.


### PR DESCRIPTION
## Summary
- Fix npm-installed CLI failing on startup due to a duplicated shebang in `dist/cli.js`.
- Keep the bundled CLI executable by chmodding the built output instead of manually prepending a shebang.
- Bundle package metadata for version output instead of reading `../../package.json` at runtime.

## Technical details
The published npm tarball for `raindrop-cli@0.1.1` contains two shebang lines at the top of `dist/cli.js`:

```js
#!/usr/bin/env node
#!/usr/bin/env node
```

Node only strips a shebang on the first line. The second line is parsed as JavaScript, causing:

```txt
SyntaxError: Invalid or unexpected token
```

`bun build` already preserves the shebang from `src/cli.ts`, so the build script should not prepend another one. This PR removes the manual prepend and runs `chmod +x dist/cli.js` instead.

After removing the duplicate shebang, running the bundled CLI exposed another packaging issue: version setup attempted to read `../../package.json` relative to the bundled file, which resolves outside the installed package layout. Importing `package.json` lets Bun inline that metadata into the bundle.

## Verification
- `bun run build`
- `node dist/cli.js --help`
- `node dist/cli.js --version`
- `bun test src/cli.integration.test.ts src/run.test.ts`
- pre-push `bun scripts/verify.ts` passed: tests, lint, typecheck, format
