### PR TITLE
feat: add release changelog preparation helper

### DIFF
--- a/.tickets/rc-g695.md
+++ b/.tickets/rc-g695.md
@@ -22,3 +22,11 @@ Started implementation on feat/release-prep-helper.
 **2026-07-15T15:53:42Z**
 
 Implemented scripts/prep-release.sh with validated, quoted tag/range handling; added bun run release:prep and documented the workflow. Verified explicit-tag and invalid-tag behavior plus bun run verify (577 tests passed).
+
+**2026-07-15T16:05:53Z**
+
+Addressing review feedback: correct no-tag file summaries and add regression coverage.
+
+**2026-07-15T16:07:31Z**
+
+Fixed initial-release file summaries by diffing the empty tree against HEAD. Added regression tests for no-tag, explicit-tag, and invalid-reference paths; bun run verify passes (580 tests).

--- a/.tickets/rc-g695.md
+++ b/.tickets/rc-g695.md
@@ -1,0 +1,24 @@
+---
+id: rc-g695
+status: closed
+deps: []
+links: []
+created: 2026-07-15T15:52:46Z
+type: feature
+priority: 2
+assignee: cc-vps
+---
+# Add release changelog preparation helper
+
+Port the release-prep helper to summarize commits since the latest tag and print an AI changelog prompt. Document it in the release workflow.
+
+
+## Notes
+
+**2026-07-15T15:52:52Z**
+
+Started implementation on feat/release-prep-helper.
+
+**2026-07-15T15:53:42Z**
+
+Implemented scripts/prep-release.sh with validated, quoted tag/range handling; added bun run release:prep and documented the workflow. Verified explicit-tag and invalid-tag behavior plus bun run verify (577 tests passed).

--- a/README.md
+++ b/README.md
@@ -360,7 +360,13 @@ Or use a [classic token](https://github.com/settings/tokens/new) with the `repo`
 
 ### Before You Release
 
-Update `CHANGELOG.md` with your changes under the `[Unreleased]` section:
+Generate a changelog draft from commits since the latest release:
+
+```bash
+bun run release:prep
+```
+
+The helper prints commit history, a changed-files summary, and a prompt you can use to draft changelog entries. Review the result and update `CHANGELOG.md` under the `[Unreleased]` section:
 
 ```markdown
 ## [Unreleased]
@@ -372,7 +378,7 @@ Update `CHANGELOG.md` with your changes under the `[Unreleased]` section:
 - Bug Y
 ```
 
-The release process will automatically move these entries to the new version section.
+The helper does not modify the changelog. The release process will automatically move your `[Unreleased]` entries to the new version section.
 
 ### Release Process
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "prepare": "lefthook install || true",
     "prepublishOnly": "ggshield secret scan path . -r --use-gitignore -y && ggshield secret scan path dist -r -y",
     "release": "release-it",
-    "release:dry": "release-it --dry-run"
+    "release:dry": "release-it --dry-run",
+    "release:prep": "./scripts/prep-release.sh"
   },
   "keywords": [
     "raindrop",

--- a/scripts/prep-release.sh
+++ b/scripts/prep-release.sh
@@ -2,7 +2,7 @@
 # Usage: ./scripts/prep-release.sh [last-tag]
 # Gathers commit information since the last release for changelog drafting.
 
-set -e
+set -euo pipefail
 
 LAST_TAG="${1:-$(git describe --tags --abbrev=0 2>/dev/null || true)}"
 
@@ -42,7 +42,9 @@ echo ""
 echo "=== Files changed ==="
 echo ""
 if [ -z "$LAST_TAG" ]; then
-  git diff --stat HEAD~20 HEAD 2>/dev/null | tail -5 || echo "(showing recent changes)"
+  # Compare against the empty tree so initial releases include the complete history.
+  EMPTY_TREE="$(git hash-object -t tree /dev/null)"
+  git diff --stat "$EMPTY_TREE" HEAD | tail -5
 else
   git diff --stat "$RANGE" | tail -10
 fi

--- a/scripts/prep-release.sh
+++ b/scripts/prep-release.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Usage: ./scripts/prep-release.sh [last-tag]
+# Gathers commit information since the last release for changelog drafting.
+
+set -e
+
+LAST_TAG="${1:-$(git describe --tags --abbrev=0 2>/dev/null || true)}"
+
+if [ -n "$LAST_TAG" ] && ! git rev-parse --verify --quiet "${LAST_TAG}^{commit}" >/dev/null; then
+  echo "Error: '$LAST_TAG' is not a valid tag or commit." >&2
+  exit 1
+fi
+
+if [ -z "$LAST_TAG" ]; then
+  RANGE="HEAD"
+else
+  RANGE="${LAST_TAG}..HEAD"
+fi
+
+echo "=== Release Prep ==="
+echo ""
+
+if [ -z "$LAST_TAG" ]; then
+  echo "No previous tag found. Showing all commits."
+else
+  echo "Changes since: $LAST_TAG"
+fi
+echo ""
+
+echo "=== Commits ==="
+echo ""
+git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges
+echo ""
+echo ""
+
+echo "=== Merged PRs (if using GitHub) ==="
+echo ""
+git log "$RANGE" --pretty=format:"%s" | grep -E "^Merge pull request|#[0-9]+" || echo "(none found)"
+echo ""
+echo ""
+
+echo "=== Files changed ==="
+echo ""
+if [ -z "$LAST_TAG" ]; then
+  git diff --stat HEAD~20 HEAD 2>/dev/null | tail -5 || echo "(showing recent changes)"
+else
+  git diff --stat "$RANGE" | tail -10
+fi
+echo ""
+echo ""
+
+echo "=== AI Prompt Template ==="
+echo ""
+cat << 'EOF'
+Review these commits and generate changelog entries in Keep a Changelog format.
+Group entries by: Added, Changed, Fixed, Removed, and Security (only include sections that have entries).
+Include only user-facing changes; exclude tests, CI, internal refactors, and routine dependency updates unless they affect users.
+Be concise. Include PR or issue numbers in parentheses where mentioned.
+
+Format example:
+### Added
+- New feature description (#123)
+
+### Fixed
+- Bug fix description
+
+Commits to review:
+EOF
+echo ""
+git log "$RANGE" --pretty=format:"- %s" --no-merges
+echo ""

--- a/src/release-prep.test.ts
+++ b/src/release-prep.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+const SCRIPT_PATH = resolve(import.meta.dir, "../scripts/prep-release.sh");
+const tempDirectories: string[] = [];
+
+function run(command: string[], cwd: string) {
+  return Bun.spawnSync(command, { cwd, stdout: "pipe", stderr: "pipe" });
+}
+
+function git(cwd: string, ...args: string[]) {
+  const result = run(["git", ...args], cwd);
+  if (result.exitCode !== 0) {
+    throw new Error(new TextDecoder().decode(result.stderr));
+  }
+}
+
+function createRepository() {
+  const directory = mkdtempSync(resolve(tmpdir(), "raindrop-cli-release-prep-"));
+  tempDirectories.push(directory);
+
+  git(directory, "init", "--quiet");
+  git(directory, "config", "user.email", "test@example.com");
+  git(directory, "config", "user.name", "Release Prep Test");
+
+  return directory;
+}
+
+function commitFile(directory: string, filename: string, content: string, message: string) {
+  writeFileSync(resolve(directory, filename), content);
+  git(directory, "add", filename);
+  git(directory, "commit", "--quiet", "-m", message);
+}
+
+function runReleasePrep(directory: string, ...args: string[]) {
+  const result = run(["bash", SCRIPT_PATH, ...args], directory);
+  return {
+    exitCode: result.exitCode,
+    stderr: new TextDecoder().decode(result.stderr),
+    stdout: new TextDecoder().decode(result.stdout),
+  };
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("release prep helper", () => {
+  test("summarizes files for an initial release without tags", () => {
+    const directory = createRepository();
+    commitFile(directory, "initial.txt", "initial release\n", "feat: initial release");
+
+    const result = runReleasePrep(directory);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No previous tag found. Showing all commits.");
+    expect(result.stdout).toMatch(/initial\.txt\s+\|\s+1 \+/);
+    expect(result.stdout).toContain("1 file changed, 1 insertion(+)");
+  });
+
+  test("uses an explicitly supplied release tag", () => {
+    const directory = createRepository();
+    commitFile(directory, "released.txt", "released\n", "feat: released change");
+    git(directory, "tag", "v1.0.0");
+    commitFile(directory, "next.txt", "next\n", "fix: next change");
+
+    const result = runReleasePrep(directory, "v1.0.0");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Changes since: v1.0.0");
+    expect(result.stdout).toContain("next.txt");
+    expect(result.stdout).not.toContain("released.txt");
+  });
+
+  test("rejects an invalid explicit release reference", () => {
+    const directory = createRepository();
+    commitFile(directory, "initial.txt", "initial release\n", "feat: initial release");
+
+    const result = runReleasePrep(directory, "not-a-revision");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Error: 'not-a-revision' is not a valid tag or commit.");
+  });
+});


### PR DESCRIPTION
## Summary
- add `bun run release:prep` to collect post-release commits and print a ready-to-use AI changelog-drafting prompt
- document the preparatory changelog workflow before the interactive release
- validate an explicitly supplied release reference and quote Git revision-range arguments

## Technical details
- `scripts/prep-release.sh` discovers the nearest tag by default, or accepts a tag/commit argument.
- It prints non-merge commits, PR-like references, and a file-change summary for the selected range.
- The output instructs an AI to retain only user-facing changes in Keep a Changelog categories; it never edits `CHANGELOG.md`.
- Invalid explicit references fail before Git history commands run.

## Verification
- `bun run release:prep`
- `bun run release:prep v0.1.1`
- invalid-reference failure path
- `bun run verify` (577 tests passed)