### PR TITLE
chore: tighten release hygiene

### DIFF
--- a/.tickets/rc-81yq.md
+++ b/.tickets/rc-81yq.md
@@ -1,0 +1,25 @@
+---
+id: rc-81yq
+status: closed
+deps: []
+links: []
+created: 2026-07-15T16:18:37Z
+type: chore
+priority: 2
+assignee: cc-vps
+parent: rd-u22
+---
+# Tighten contribution and build hygiene
+
+Apply the contribution policy and clean-build behavior established in ticktick-cli PR #69 to raindrop-cli.
+
+## Acceptance Criteria
+
+CONTRIBUTING.md states the personal-maintainer policy; README aligns; each build removes stale dist output before generating artifacts.
+
+
+## Notes
+
+**2026-07-15T16:19:16Z**
+
+Implemented the personal-maintainer contribution policy and clean build step. Validated with bun run build, npm pack --dry-run (90 files), and bun run verify (580 passed).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,41 +1,23 @@
-# Contributing to raindrop-cli
+# Contributing
 
-## Prerequisites
+Thanks for your interest in raindrop-cli.
 
-- Node.js 20+
-- Bun (for development)
+This is a personally maintained project. I am not accepting code contributions,
+pull requests, or feature requests at this time. Unsolicited pull requests may
+be closed without review.
 
-## Setup
+## Bug reports
 
-```bash
-git clone https://github.com/crcatala/raindrop-cli.git
-cd raindrop-cli
-bun install
-```
+Bug reports are welcome when they include a clear reproduction, the CLI version,
+your operating system, Node.js version, and relevant error output. Please search
+existing issues before opening a new one.
 
-## Development
+## Security issues
 
-```bash
-bun run verify    # Run all checks (lint, typecheck, test, format)
-bun run build     # Build for production
-bun run dev       # Watch mode
-```
+Please do not report security vulnerabilities in a public issue. Contact
+[@crcatala](https://github.com/crcatala) privately instead.
 
-## Running Live Tests
+## Forks
 
-Live tests require a Raindrop.io API token:
-
-```bash
-export RAINDROP_TOKEN=your-test-token
-bun run test:live
-```
-
-**Note:** Use a dedicated test account, not your personal bookmarks.
-
-## Pull Request Process
-
-1. Fork the repo
-2. Create a feature branch
-3. Make your changes
-4. Run `bun run verify`
-5. Submit PR
+You are welcome to fork this project and adapt it to your own needs under the
+terms of the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ npx raindrop-cli@latest --version
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
+This is a personally maintained project and does not accept code contributions, pull requests, or feature requests. Bug reports with a clear reproduction are welcome; see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 Quick start:
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "bun build src/cli.ts --outdir dist --target node --format esm && chmod +x dist/cli.js && bun run build:dts",
+    "clean": "node -e \"for (const path of ['dist', 'tsconfig.tsbuildinfo']) require('node:fs').rmSync(path, { recursive: true, force: true })\"",
+    "build": "bun run clean && bun build src/cli.ts --outdir dist --target node --format esm && chmod +x dist/cli.js && bun run build:dts",
     "build:dts": "tsc --emitDeclarationOnly --declaration --outDir dist",
     "dev": "bun src/index.ts",
     "test": "bash scripts/check.sh test",


### PR DESCRIPTION
## Summary

- clean `dist` and TypeScript build metadata before each package build
- replace the contribution guide with the personal-maintainer policy
- align the README contribution section with that policy

## Validation

- `bun run build`
- `npm pack --dry-run` (90 files)
- `bun run verify` (580 passed)