### PR TITLE
fix: make release dry run non-mutating

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,12 +387,14 @@ The helper does not modify the changelog. The release process will automatically
 git checkout main
 git pull
 
-# 2. Preview what will happen (recommended first time)
+# 2. Preview the local release steps (recommended first time)
 bun run release:dry
 
 # 3. Run the release
 bun run release
 ```
+
+`release:dry` deliberately disables the npm and GitHub integrations, so it cannot publish or open GitHub's release form. Run `release` for the full process.
 
 The interactive prompt will ask you to select the version bump (patch/minor/major). Then release-it will:
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prepare": "lefthook install || true",
     "prepublishOnly": "ggshield secret scan path . -r --use-gitignore -y && ggshield secret scan path dist -r -y",
     "release": "release-it",
-    "release:dry": "release-it --dry-run",
+    "release:dry": "release-it --dry-run --no-npm --no-github",
     "release:prep": "./scripts/prep-release.sh"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- disable npm and GitHub integrations in `release:dry`
- prevent fallback GitHub release-form browser launches and npm version bumps during previews
- document the intentionally local-only dry-run behavior

## Verification
- `bun run release:dry -- --ci --git.requireCleanWorkingDir=false`
- pre-push `bun scripts/verify.ts` (580 tests passed)