### PR TITLE
fix: ensure npm releases use a fresh tested artifact

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -19,7 +19,7 @@
   },
   "hooks": {
     "before:init": ["bash scripts/check-changelog.sh", "bun run verify"],
-    "after:bump": ["bun run build"]
+    "after:bump": ["bun run test:package"]
   },
   "plugins": {
     "@release-it/keep-a-changelog": {

--- a/.tickets/rc-vp7m.md
+++ b/.tickets/rc-vp7m.md
@@ -1,6 +1,6 @@
 ---
 id: rc-vp7m
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-07-15T16:53:17Z
@@ -16,3 +16,9 @@ The npm 0.1.1 tarball contains two #!/usr/bin/env node lines in dist/cli.js and 
 
 A newly published npm version has exactly one shebang in dist/cli.js; npm install -g raindrop-cli && rd --version succeeds; npx raindrop-cli --help succeeds; npm info raindrop-cli shows the corrected version as latest.
 
+
+## Notes
+
+**2026-07-15T17:14:15Z**
+
+Verified the published 0.2.0 tarball directly: dist/cli.js has exactly one shebang (mode 755); isolated global installation runs rd --version; npx raindrop-cli@0.2.0 --help passes; npm latest is 0.2.0. Hardened release flow so after:bump runs the package smoke test, direct pack/publish rebuilds via prepack, and the smoke test asserts one shebang.

--- a/README.md
+++ b/README.md
@@ -401,11 +401,11 @@ The interactive prompt will ask you to select the version bump (patch/minor/majo
 1. **Verify** — runs tests, lint, typecheck, format
 2. **Bump version** — updates `package.json`
 3. **Update changelog** — moves "Unreleased" items to new version section with date
-4. **Build** — compiles to `dist/`
+4. **Package smoke test** — rebuilds `dist/`, packs it, and executes the installed `rd` CLI
 5. **Commit** — creates "chore: release vX.Y.Z" commit
 6. **Tag** — creates `vX.Y.Z` git tag
-7. **Secret scan** — ggshield scans for leaked secrets
-8. **Publish to npm** — uploads package
+7. **Secret scan** — ggshield scans a freshly rebuilt `dist/` for leaked secrets
+8. **Publish to npm** — rebuilds immediately before packing and uploads the artifact
 9. **Push** — pushes commit and tag to GitHub
 10. **GitHub Release** — creates release with changelog notes
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "verify": "bun scripts/verify.ts",
     "verify:verbose": "VERBOSE=1 bun scripts/verify.ts",
     "prepare": "lefthook install || true",
-    "prepublishOnly": "ggshield secret scan path . -r --use-gitignore -y && ggshield secret scan path dist -r -y",
+    "prepack": "bun run build",
+    "prepublishOnly": "bun run build && ggshield secret scan path . -r --use-gitignore -y && ggshield secret scan path dist -r -y",
     "release": "release-it",
     "release:dry": "release-it --dry-run --no-npm --no-github",
     "release:prep": "./scripts/prep-release.sh"

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -19,10 +19,19 @@ trap cleanup EXIT
 
 bun run build >/dev/null
 
-TARBALL="$(npm pack --silent | tail -n 1)"
+# dist was built above; do not run lifecycle scripts again while packing the
+# artifact under test. `prepack` separately guarantees direct npm publish
+# commands rebuild dist immediately before upload.
+TARBALL="$(npm pack --ignore-scripts --silent | tail -n 1)"
 npm install -g --prefix "$TMP_DIR/prefix" --ignore-scripts "./$TARBALL" >/dev/null
 
-BIN="$TMP_DIR/prefix/bin/rdcli"
+SHEBANG_COUNT="$(grep -c '^#!' dist/cli.js || true)"
+if [[ "$SHEBANG_COUNT" != "1" ]]; then
+  echo "Expected dist/cli.js to have exactly one shebang, got $SHEBANG_COUNT" >&2
+  exit 1
+fi
+
+BIN="$TMP_DIR/prefix/bin/rd"
 EXPECTED_VERSION="$(node -p "require('./package.json').version")"
 ACTUAL_VERSION="$($BIN --version)"
 


### PR DESCRIPTION
## Summary
- rebuild `dist` in npm pack/publish lifecycle hooks
- smoke-test the packed CLI after release version bump, including an explicit single-shebang assertion
- document the strengthened release sequence

## Verification
- `bun run test:package`
- `npx --yes raindrop-cli@0.2.0 --help`
- fresh `npm pack` artifact shebang check