### PR TITLE
Fix auth whoami alias

### DIFF
--- a/.tickets/rc-fa9w.md
+++ b/.tickets/rc-fa9w.md
@@ -1,0 +1,20 @@
+---
+id: rc-fa9w
+status: closed
+deps: []
+links: []
+created: 2026-07-15T17:58:54Z
+type: bug
+priority: 2
+assignee: cc-vps
+---
+# Add auth whoami alias
+
+Add rd auth whoami as an alias for rd auth status. Ensure Commander delegation uses only the selected subcommand arguments to avoid the too-many-arguments regression fixed in ticktick-cli PR #73.
+
+
+## Notes
+
+**2026-07-15T18:00:10Z**
+
+Verified ticktick-cli PR #73's Commander parseAsync issue. Added rd auth whoami as a status alias, passing only status arguments with from: user. Added plain and JSON integration regressions. Verified bun run test (582 pass), typecheck, lint, and format.

--- a/src/cli.integration.test.ts
+++ b/src/cli.integration.test.ts
@@ -153,6 +153,20 @@ describe("CLI integration", () => {
         expect(() => JSON.parse(result.stdout)).not.toThrow();
       }
     });
+
+    test("auth whoami delegates to auth status without extra arguments", async () => {
+      const result = await runCli(["auth", "whoami"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain("too many arguments");
+    });
+
+    test("auth whoami --json outputs authentication status as JSON", async () => {
+      const result = await runCli(["auth", "whoami", "--json"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ authenticated: false });
+    });
   });
 
   describe("stream separation", () => {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -225,6 +225,20 @@ Examples:
       }
     });
 
+  // whoami command (alias for status)
+  auth
+    .command("whoami")
+    .description("Show the authenticated user")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      // Parse only the status command's arguments. With `from: "user"`,
+      // including "status" here makes Commander treat it as an extra argument.
+      const statusCmd = auth.commands.find((command) => command.name() === "status");
+      if (statusCmd) {
+        await statusCmd.parseAsync(options.json ? ["--json"] : [], { from: "user" });
+      }
+    });
+
   // clear command
   auth
     .command("clear")


### PR DESCRIPTION
## Summary

Adds `rd auth whoami` as an alias for `rd auth status`, matching the related ticktick-cli command.

The alias delegates using only the status command arguments when parsing with Commander `from: "user"`; including `status` itself would be parsed as an unexpected positional argument (the failure fixed in ticktick-cli PR #73).

## Testing

- `bun run test` (582 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`