### PR TITLE
chore(renovate): adopt the shared fleet preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,47 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
-  "dependencyDashboard": true,
-  "schedule": ["before 5am on Monday"],
-  "platformAutomerge": true,
-  "automergeStrategy": "squash",
-  "labels": ["dependencies"],
-  "assignees": ["@crcatala"],
-  "minimumReleaseAge": "7 days",
-  "osvVulnerabilityAlerts": true,
-  "dependencyDashboardOSVVulnerabilitySummary": "all",
-  "ignoreScripts": true,
-  "lockFileMaintenance": {
-    "enabled": true
-  },
-  "packageRules": [
-    {
-      "description": "Automerge stable (non-0.x) minor/patch updates",
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    },
-    {
-      "description": "Automerge minor/patch dev dependency updates (build tooling; CI validates)",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    },
-    {
-      "description": "TypeScript - can introduce breaking type checks; review manually",
-      "matchPackageNames": ["typescript"],
-      "automerge": false,
-      "groupName": null
-    },
-    {
-      "description": "Group type definitions into a single PR",
-      "matchPackagePatterns": ["^@types/"],
-      "groupName": "type definitions"
-    },
-    {
-      "description": "Never automerge major updates; require human review",
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    }
+  "extends": [
+    "github>crcatala/renovate-config"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>crcatala/renovate-config"
-  ]
+  "extends": ["github>crcatala/renovate-config"]
 }


### PR DESCRIPTION
Replaces this repo's standalone Renovate config with the shared fleet preset at [`crcatala/renovate-config`](https://github.com/crcatala/renovate-config).

## Why now

**Renovate 42 (2025-11-06) changed the default of `minimumReleaseAgeBehaviour` to `timestamp-required`.** Under that default, an update whose datasource reports no release timestamp is held **indefinitely** rather than failed — so its `renovate/stability-days` status sits pending forever and the PR can never merge.

Two common update types have no release timestamp:

| Update type | Why no timestamp |
|---|---|
| `github-actions` | `helpers:pinGitHubActionDigestsToSemver` resolves updates to commit SHAs. A SHA points at a commit, not a published release. |
| `lockFileMaintenance` | Adopts no version at all — it regenerates the lockfile. |

Across the fleet this left **7 PRs stuck in 6 repos**, all green and all unmergeable, the oldest since 2026-01-26.

The preset sets `minimumReleaseAgeBehaviour: "timestamp-optional"`, which keeps the cooldown enforced everywhere a timestamp exists (npm, RubyGems — where it was always doing the real work) and lets undatable updates through instead of parking them.

## Why a shared preset

Fifteen repos carried near-identical configs that had drifted apart — schedules differing only by hour and casing, inconsistent automerge posture, and this bug present in all of them. The preset resolves **live** from its default branch, so the next fleet-wide policy change is one edit in one repo instead of fifteen PRs like this one.

There is deliberately **one** preset rather than per-language files. Renovate package rules are inert when they do not match, so a single preset carries npm, Bundler, Python, Go, Rust, container and GitHub Actions rules at once and each repo silently gets only what applies. Rules already ship for managers no repo uses yet, so a future Go or Rust repo needs no config change.

## What this repo inherits

`config:recommended` + SHA-pinned actions, weekly Monday schedule, `dependencies` label, OSV alerts, `ignoreScripts`, squash automerge, **7-day release cooldown**, monthly lockfile maintenance, per-ecosystem grouping, and: stable non-0.x minor/patch automerge on green; 0.x minors and **all majors never automerge**.

## Verified

Config validated with `renovate-config-validator` (all 14 repo configs and the preset itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
